### PR TITLE
[GT-134] JDBC URL, Class 변경에 따른 plugin 정보 변경

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.turbographpp/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.turbographpp/plugin.xml
@@ -82,9 +82,10 @@
                         webURL="https://www.cubrid.org/manual/en/11.2/api/jdbc.html#configuration-connection"
                         categories="vit_graph">
                     <file 
-                    	path="https://github.com/cubrid-iitp/turbograph-jdbc-maven/releases/download/1.0.0.0006/turbograph-jdbc-1.0.0.0006.jar"
+                    	path="maven:/turbograph:turbograph-jdbc:RELEASE"
                     	type="jar">
                     </file>
+
 
                     <property name="altHosts" value=""/>
                     <property name="rcTime" value="600"/>
@@ -115,8 +116,8 @@
     </extension>
 
 	<extension point="org.jkiss.dbeaver.mavenRepository">
-        <repository id="cubrid-turbograph-maven-repo" name="turbograph Repository" url="https://nexus.buabu.duckdns.org/repository/maven-releases/">
-            <scope group="cubrid"/>
+        <repository id="cubrid-turbograph-maven-repo" name="turbograph Repository" url="https://web.buabu.duckdns.org/cubrid">
+            <scope group="turbograph"/>
         </repository>
     </extension>
 


### PR DESCRIPTION
http://jira.iitp.cubrid.org/browse/GT-134

- dbeaver plugin에서는 github repo 가 동작되지 않아 nginx를 이용한 repo로 변경